### PR TITLE
bug fix for 449

### DIFF
--- a/Spring/pom.xml
+++ b/Spring/pom.xml
@@ -15,7 +15,7 @@
 		<spring.boot.version>2.1.6.RELEASE</spring.boot.version>
 		<junit.jupiter.version>5.6.2</junit.jupiter.version>
 		<junit.platform.version>1.6.2</junit.platform.version>
-		<pbz.server.version>1.0.13</pbz.server.version>
+		<pbz.server.version>1.0.14</pbz.server.version>
 	</properties>
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/Spring/src/main/java/com/pbz/demo/hello/util/FileUtil.java
+++ b/Spring/src/main/java/com/pbz/demo/hello/util/FileUtil.java
@@ -10,6 +10,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
@@ -18,6 +21,10 @@ import java.nio.file.Paths;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSessionContext;
 
 import org.jaudiotagger.audio.mp3.MP3AudioHeader;
 import org.jaudiotagger.audio.mp3.MP3File;
@@ -156,7 +163,23 @@ public class FileUtil {
 		try {
 			url = fixUrl(url);
 			URL fileUrl = new URL(url);
-			InputStream is = fileUrl.openStream();
+			InputStream is = null;
+			// Proxy
+			boolean b = false;
+			if (b) {
+				javax.net.ssl.TrustManager[] trustAllCerts = { new TrustAllTrustManager() };
+				SSLContext sc = SSLContext.getInstance("SSL");
+				SSLSessionContext sslsc = sc.getServerSessionContext();
+				sslsc.setSessionTimeout(0);
+				sc.init(null, trustAllCerts, null);
+				HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+				HttpsURLConnection.setDefaultHostnameVerifier(new NullHostnameVerifier());
+				Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 4567));
+				HttpURLConnection urlc = (HttpURLConnection) fileUrl.openConnection(proxy);
+				is = urlc.getInputStream();
+			} else {
+				is = fileUrl.openStream();
+			}
 			OutputStream os = new FileOutputStream(saveFilePath);
 			byte bf[] = new byte[1024];
 			int length = 0;
@@ -166,7 +189,7 @@ public class FileUtil {
 			is.close();
 			os.close();
 		} catch (Exception e) {
-			System.out.println(e.getMessage());
+			System.out.println("Error:" + e.getMessage());
 		}
 	}
 
@@ -279,5 +302,41 @@ public class FileUtil {
 		}
 		return result;
 
+	}
+
+	public static void main(String[] args) {
+
+		// 全局代理
+		// Properties prop = System.getProperties();
+		// prop.setProperty("socksProxyHost", "localhost");
+		// prop.setProperty("socksProxyPort", "4567");
+
+		// https://learningenglish.voanews.com/z/3521&filename=AsItIs.html
+		String strUrl = "https://learningenglish.voanews.com/z/3521";
+		// strUrl = "http://news.baidu.com";
+		// strUrl = "https://www.google.com";
+		// ProxySelector.getDefault();
+		// System.setProperty("java.net.preferIPv4Stack", "true");
+		// System.setProperty("jdk.tls.useExtendedMasterSecret", "false");
+		downloadFile(strUrl, "/Users/jeremy/temp/asItis.html");
+		try {
+			URL url = new URL(strUrl);
+			InetSocketAddress addr = new InetSocketAddress("localhost", 4567);
+			Proxy proxy = new Proxy(Proxy.Type.SOCKS, addr); // Socket 代理
+			URLConnection conn = url.openConnection(proxy);
+			InputStream is = conn.getInputStream();
+			OutputStream os = new FileOutputStream("/Users/jeremy/temp/download1.html");
+			byte bf[] = new byte[1024];
+			int length = 0;
+			while ((length = is.read(bf, 0, 1024)) != -1) {
+				os.write(bf, 0, length);
+			}
+			is.close();
+			os.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+			System.out.println(e.getMessage());
+		}
+		System.out.println("OK!");
 	}
 }

--- a/Spring/src/main/java/com/pbz/demo/hello/util/NullHostnameVerifier.java
+++ b/Spring/src/main/java/com/pbz/demo/hello/util/NullHostnameVerifier.java
@@ -1,0 +1,10 @@
+package com.pbz.demo.hello.util;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+public class NullHostnameVerifier implements HostnameVerifier {
+	public boolean verify(String hostname, SSLSession session) {
+		return true;
+	}
+}

--- a/Spring/src/main/java/com/pbz/demo/hello/util/TrustAllTrustManager.java
+++ b/Spring/src/main/java/com/pbz/demo/hello/util/TrustAllTrustManager.java
@@ -1,0 +1,22 @@
+package com.pbz.demo.hello.util;
+
+public class TrustAllTrustManager implements javax.net.ssl.TrustManager, javax.net.ssl.X509TrustManager {
+
+	@Override
+	public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+		return null;
+	}
+
+	@Override
+	public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType)
+			throws java.security.cert.CertificateException {
+		return;
+	}
+
+	@Override
+	public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType)
+			throws java.security.cert.CertificateException {
+		return;
+	}
+
+}

--- a/node1/test/python.js
+++ b/node1/test/python.js
@@ -3,6 +3,6 @@ const app = require('../app/python');
 
 describe('python', function(){
   it('test: python', function(){
-    assert.equal(app(),'to test python: doing.');
+    assert.equal(app(),'to test python: done.');
   });
 });

--- a/node1/test/python.js
+++ b/node1/test/python.js
@@ -3,6 +3,6 @@ const app = require('../app/python');
 
 describe('python', function(){
   it('test: python', function(){
-    assert.equal(app(),'to test python: done.');
+    assert.equal(app(),'to test python: doing.');
   });
 });


### PR DESCRIPTION
尝试用在代码中设置代理的办法解决 #449，但最终发现问题的原因并不是代理引起的，而是DNS服务无法识别域名“learningenglish.voanews.com”
故最终的解决办法是在C:\Windows\System32\drivers\etc\hosts增加对应的域名解析，配置详见issue449

这里尝试的代码虽然没有解决这个问题，但我建议保留已备他用